### PR TITLE
MARKDOWN-80: Replace usage of RawBlock by the HTML macro

### DIFF
--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLExtension.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLExtension.java
@@ -33,7 +33,7 @@ public class DeepInlineHTMLExtension implements Parser.ParserExtension
     @Override
     public void parserOptions(MutableDataHolder mutableDataHolder)
     {
-
+        // This parser extension currently does not have any configurable options.
     }
 
     @Override

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLExtension.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLExtension.java
@@ -17,43 +17,38 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.contrib.rendering.markdown.commonmark12.internal;
+package org.xwiki.contrib.rendering.markdown.commonmark12.internal.parser;
 
-import java.util.Collections;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import org.slf4j.Logger;
-import org.xwiki.component.annotation.Component;
-import org.xwiki.contrib.rendering.markdown.commonmark12.internal.parser.DeepInlineHTMLExtension;
-
-import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension;
-import com.vladsch.flexmark.parser.ParserEmulationProfile;
+import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.data.MutableDataHolder;
 
-@Component
-@Singleton
-public class DefaultMarkdownConfiguration extends AbstractMarkdownConfiguration implements MarkdownConfiguration
+/**
+ * This extension provides DeepInlineHTMLPostProcessor as a parsing post processor.
+ *
+ * @version $Id$
+ * @since 8.9
+ */
+public class DeepInlineHTMLExtension implements Parser.ParserExtension
 {
-    @Inject
-    private Logger logger;
-
     @Override
-    public MutableDataHolder getOptions()
+    public void parserOptions(MutableDataHolder mutableDataHolder)
     {
-        MutableDataHolder options = getDefaultOptions(ParserEmulationProfile.COMMONMARK,
-            Collections.singletonList(DeepInlineHTMLExtension.class));
 
-        // Configure other options
-        options.set(WikiLinkExtension.IMAGE_LINKS, true);
-
-        return options;
     }
 
     @Override
-    protected Logger getLogger()
+    public void extend(Parser.Builder builder)
     {
-        return this.logger;
+        builder.postProcessorFactory(new DeepInlineHTMLPostProcessor.Factory(builder));
+    }
+
+    /**
+     * Creates an instance of DeepInlineHTMLExtension.
+     *
+     * @return a new instance of this extension
+     */
+    public static DeepInlineHTMLExtension create()
+    {
+        return new DeepInlineHTMLExtension();
     }
 }

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
@@ -42,7 +42,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
     private static final String HTML_OPEN_PREFIX = "<";
     private static final String HTML_CLOSE_PREFIX = "</";
     private static final String HTML_SELF_SUFFIX = "/>";
-    private static final String HTML_REGULAR_SUFFIX = ">";
+    private static final String HTML_TAG_SUFFIX = "\\s+|>";
 
     /**
      * Factory class for DeepInlineHTMLPostProcessor.
@@ -85,7 +85,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
         }
 
         // We keep the name of the tag until the first whitespace character and remove the angle brackets.
-        String inlineStartTag = inlineStartText.split("\\s+|" + HTML_REGULAR_SUFFIX)[0].substring(1);
+        String inlineStartTag = inlineStartText.split(HTML_TAG_SUFFIX)[0].substring(1);
 
         while (nextNode != null && nFound < toFind) {
             Node currentNode = nextNode;
@@ -96,7 +96,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
 
             if (currentNode instanceof HtmlInline) {
                 // We keep the name of the tag until the first whitespace character or closing angle bracket.
-                String currentNodeTag = currentNode.getChars().toString().split("\\s+|" + HTML_REGULAR_SUFFIX)[0];
+                String currentNodeTag = currentNode.getChars().toString().split(HTML_TAG_SUFFIX)[0];
                 if (currentNodeTag.equals(HTML_OPEN_PREFIX + inlineStartTag)) {
                     toFind++;
                 } else if (currentNodeTag.equals(HTML_CLOSE_PREFIX + inlineStartTag)) {

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
@@ -42,6 +42,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
     private static final String HTML_OPEN_PREFIX = "<";
     private static final String HTML_CLOSE_PREFIX = "</";
     private static final String HTML_SELF_SUFFIX = "/>";
+    private static final String HTML_REGULAR_SUFFIX = ">";
 
     /**
      * Factory class for DeepInlineHTMLPostProcessor.
@@ -83,8 +84,8 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
             return;
         }
 
-        // We keep the name of the tag until the first whitespace character.
-        String inlineStartTag = inlineStartText.split("\\s+")[0].substring(1);
+        // We keep the name of the tag until the first whitespace character and remove the angle brackets.
+        String inlineStartTag = inlineStartText.split("\\s+|" + HTML_REGULAR_SUFFIX)[0].substring(1);
 
         while (nextNode != null && nFound < toFind) {
             Node currentNode = nextNode;
@@ -94,10 +95,11 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
             node.setChars(node.getChars().append(currentNode.getChars()));
 
             if (currentNode instanceof HtmlInline) {
-                String currentNodeText = currentNode.getChars().toString();
-                if (currentNodeText.startsWith(HTML_OPEN_PREFIX + inlineStartTag)) {
+                // We keep the name of the tag until the first whitespace character or closing angle bracket.
+                String currentNodeTag = currentNode.getChars().toString().split("\\s+|" + HTML_REGULAR_SUFFIX)[0];
+                if (currentNodeTag.equals(HTML_OPEN_PREFIX + inlineStartTag)) {
                     toFind++;
-                } else if (currentNodeText.startsWith(HTML_CLOSE_PREFIX + inlineStartTag)) {
+                } else if (currentNodeTag.equals(HTML_CLOSE_PREFIX + inlineStartTag)) {
                     nFound++;
                 }
             }

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
@@ -87,7 +87,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
         }
 
         // We keep the name of the tag until the first whitespace character and remove the angle brackets.
-        String inlineStartTag = HTML_TAG_SUFFIX_REGEX.split(inlineStartText)[0].substring(1);
+        String inlineStartTag = HTML_TAG_SUFFIX_REGEX.split(inlineStartText, 2)[0].substring(1);
 
         while (nextNode != null && nFound < toFind) {
             Node currentNode = nextNode;
@@ -98,7 +98,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
 
             if (currentNode instanceof HtmlInline) {
                 // We keep the name of the tag until the first whitespace character or closing angle bracket.
-                String currentNodeTag = HTML_TAG_SUFFIX_REGEX.split(currentNode.getChars().toString())[0];
+                String currentNodeTag = HTML_TAG_SUFFIX_REGEX.split(currentNode.getChars().toString(), 2)[0];
                 if (currentNodeTag.equals(HTML_OPEN_PREFIX + inlineStartTag)) {
                     toFind++;
                 } else if (currentNodeTag.equals(HTML_CLOSE_PREFIX + inlineStartTag)) {

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
@@ -1,0 +1,110 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.rendering.markdown.commonmark12.internal.parser;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.vladsch.flexmark.ast.HtmlInline;
+import com.vladsch.flexmark.parser.block.NodePostProcessor;
+import com.vladsch.flexmark.parser.block.NodePostProcessorFactory;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.ast.NodeTracker;
+import com.vladsch.flexmark.util.data.DataHolder;
+
+/**
+ * Detects and merges nodes that are content of inline HTML open and close tags.
+ * In a situation where a paragraph contains an open tag without any corresponding closing tag, the rest of the
+ * paragraph content will be treated as a single HtmlInline node.
+ *
+ * @version $Id$
+ * @since 8.9
+ */
+public class DeepInlineHTMLPostProcessor extends NodePostProcessor
+{
+    private static final String HTML_OPEN_PREFIX = "<";
+    private static final String HTML_CLOSE_PREFIX = "</";
+    private static final String HTML_SELF_SUFFIX = "/>";
+
+    /**
+     * Factory class for DeepInlineHTMLPostProcessor.
+     */
+    public static class Factory extends NodePostProcessorFactory
+    {
+        /**
+         * Factory constructor.
+         *
+         * @param options parser configuration
+         */
+        public Factory(DataHolder options)
+        {
+            super(false);
+            addNodes(HtmlInline.class);
+        }
+
+        @NotNull
+        @Override
+        public NodePostProcessor apply(@NotNull Document document)
+        {
+            return new DeepInlineHTMLPostProcessor();
+        }
+    }
+
+    @Override
+    public void process(@NotNull NodeTracker nodeTracker, @NotNull Node node)
+    {
+        // We store the number of nested open tags found during the processing and match it to the number of closing
+        // tags.
+        int toFind = 1;
+        int nFound = 0;
+
+        Node nextNode = node.getNext();
+        String inlineStartText = node.getChars().toString();
+
+        // We return early if we found a single closing tag, or a self-closing one.
+        if (inlineStartText.startsWith(HTML_CLOSE_PREFIX) || inlineStartText.endsWith(HTML_SELF_SUFFIX)) {
+            return;
+        }
+
+        // We keep the name of the tag until the first whitespace character.
+        String inlineStartTag = inlineStartText.split("\\s+")[0].substring(1);
+
+        while (nextNode != null && nFound < toFind) {
+            Node currentNode = nextNode;
+            nextNode = nextNode.getNext();
+
+            // We store the content of the processed nodes in the first HtmlInline node.
+            node.setChars(node.getChars().append(currentNode.getChars()));
+
+            if (currentNode instanceof HtmlInline) {
+                String currentNodeText = currentNode.getChars().toString();
+                if (currentNodeText.startsWith(HTML_OPEN_PREFIX + inlineStartTag)) {
+                    toFind++;
+                } else if (currentNodeText.startsWith(HTML_CLOSE_PREFIX + inlineStartTag)) {
+                    nFound++;
+                }
+            }
+
+            // We get rid of now redundant nodes.
+            currentNode.unlink();
+            nodeTracker.nodeRemoved(currentNode);
+        }
+    }
+}

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/DeepInlineHTMLPostProcessor.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.contrib.rendering.markdown.commonmark12.internal.parser;
 
+import java.util.regex.Pattern;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.vladsch.flexmark.ast.HtmlInline;
@@ -42,7 +44,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
     private static final String HTML_OPEN_PREFIX = "<";
     private static final String HTML_CLOSE_PREFIX = "</";
     private static final String HTML_SELF_SUFFIX = "/>";
-    private static final String HTML_TAG_SUFFIX = "\\s+|>";
+    private static final Pattern HTML_TAG_SUFFIX_REGEX = Pattern.compile("\\s+|>");
 
     /**
      * Factory class for DeepInlineHTMLPostProcessor.
@@ -85,7 +87,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
         }
 
         // We keep the name of the tag until the first whitespace character and remove the angle brackets.
-        String inlineStartTag = inlineStartText.split(HTML_TAG_SUFFIX)[0].substring(1);
+        String inlineStartTag = HTML_TAG_SUFFIX_REGEX.split(inlineStartText)[0].substring(1);
 
         while (nextNode != null && nFound < toFind) {
             Node currentNode = nextNode;
@@ -96,7 +98,7 @@ public class DeepInlineHTMLPostProcessor extends NodePostProcessor
 
             if (currentNode instanceof HtmlInline) {
                 // We keep the name of the tag until the first whitespace character or closing angle bracket.
-                String currentNodeTag = currentNode.getChars().toString().split(HTML_TAG_SUFFIX)[0];
+                String currentNodeTag = HTML_TAG_SUFFIX_REGEX.split(currentNode.getChars().toString())[0];
                 if (currentNodeTag.equals(HTML_OPEN_PREFIX + inlineStartTag)) {
                     toFind++;
                 } else if (currentNodeTag.equals(HTML_CLOSE_PREFIX + inlineStartTag)) {

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/HTMLNodeVisitor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/HTMLNodeVisitor.java
@@ -21,6 +21,7 @@ package org.xwiki.contrib.rendering.markdown.commonmark12.internal.parser;
 
 import java.util.Deque;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.rendering.listener.Listener;
 
 import com.vladsch.flexmark.ast.HtmlBlock;
@@ -73,7 +74,7 @@ public class HTMLNodeVisitor extends AbstractNodeVisitor
         String outputHtml = renderer.render(parsedNode);
 
         // Parsing the node on its own will put in a paragraph, so we remove <p></p> tags and linebreak from the output.
-        generateHTMLMacro(outputHtml.substring(3, outputHtml.length() - 5), true);
+        generateHTMLMacro(StringUtils.removeEnd(StringUtils.removeStart(outputHtml, "<p>"), "</p>\n"), true);
     }
 
     public void visit(HtmlBlock node)

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/HTMLNodeVisitor.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/parser/HTMLNodeVisitor.java
@@ -28,9 +28,12 @@ import com.vladsch.flexmark.ast.HtmlCommentBlock;
 import com.vladsch.flexmark.ast.HtmlEntity;
 import com.vladsch.flexmark.ast.HtmlInline;
 import com.vladsch.flexmark.ast.HtmlInlineComment;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.ast.NodeVisitor;
 import com.vladsch.flexmark.util.ast.VisitHandler;
+import com.vladsch.flexmark.util.data.MutableDataSet;
 
 /**
  * Handle HTML events.
@@ -58,7 +61,19 @@ public class HTMLNodeVisitor extends AbstractNodeVisitor
 
     public void visit(HtmlInline node)
     {
-        visit((Node) node);
+        // When we have an inline HTML macro with its raw content, we need to parse it and render it as HTML to
+        // support possibly embedded Markdown content.
+        MutableDataSet options = new MutableDataSet();
+        // We already know we are in an inline context, so we disable block parsing.
+        options.set(Parser.HTML_BLOCK_PARSER, false);
+        Parser parser = Parser.builder(options).build();
+        Node parsedNode = parser.parse(node.getChars().toString());
+
+        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        String outputHtml = renderer.render(parsedNode);
+
+        // Parsing the node on its own will put in a paragraph, so we remove <p></p> tags and linebreak from the output.
+        generateHTMLMacro(outputHtml.substring(3, outputHtml.length() - 5), true);
     }
 
     public void visit(HtmlBlock node)

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/Markdown12ChainingRenderer.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/Markdown12ChainingRenderer.java
@@ -216,4 +216,32 @@ public class Markdown12ChainingRenderer extends Markdown11ChainingRenderer
         }
         return false;
     }
+
+    protected boolean handleHtmlMacro(String id, Map<String, String> parameters, String content, boolean isInline)
+    {
+        boolean isHandled = false;
+
+        if (id.equals("html")) {
+            if (!isInline) {
+                printEmptyLine();
+            }
+
+            // Use Markdown printer to escape content inside HTML macros
+            getMarkdownPrinter().printDelayed(createMacroPrinter().renderMacro(id, parameters, content, isInline));
+            getMarkdownPrinter().flush();
+            isHandled = true;
+        }
+
+        return isHandled;
+    }
+
+    @Override
+    public void onMacro(String id, Map<String, String> parameters, String content, boolean isInline)
+    {
+        if (handleHtmlMacro(id, parameters, content, isInline)) {
+            return;
+        }
+
+        super.onMacro(id, parameters, content, isInline);
+    }
 }

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/MarkdownEscapeHandler.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/MarkdownEscapeHandler.java
@@ -84,9 +84,14 @@ public class MarkdownEscapeHandler
 
         // Escape reserved keywords
         Matcher matcher = RESERVED_CHARS_PATTERN.matcher(accumulatedBuffer.toString());
-        for (int i = 0; matcher.find(); i = i + matcher.end() - matcher.start() + 1) {
-            accumulatedBuffer.replace(matcher.start() + i, matcher.end() + i, ESCAPE_CHAR + matcher.group().charAt(0)
-                + ESCAPE_CHAR + matcher.group().charAt(1));
+        for (int i = 0; matcher.find(); i = i + matcher.group().length()) {
+            if (matcher.group().length() == 1) {
+                accumulatedBuffer.replace(matcher.start() + i, matcher.end() + i,
+                    ESCAPE_CHAR + matcher.group().charAt(0));
+            } else {
+                accumulatedBuffer.replace(matcher.start() + i, matcher.end() + i,
+                    ESCAPE_CHAR + matcher.group().charAt(0) + ESCAPE_CHAR + matcher.group().charAt(1));
+            }
         }
 
         // TODO: Handle escaping link syntax, i.e. |(?<!\)[.*]\(.*\)

--- a/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/MarkdownMacroRenderer.java
+++ b/syntax-markdown-commonmark12/src/main/java/org/xwiki/contrib/rendering/markdown/commonmark12/internal/renderer/MarkdownMacroRenderer.java
@@ -45,6 +45,8 @@ public class MarkdownMacroRenderer
 
     private static final String NEWLINE = "\n";
 
+    private static final String HTML_ID = "html";
+
     private static final ParametersPrinter PARAMETERS_PRINTER = new ParametersPrinter('\\');
 
     /**
@@ -71,7 +73,7 @@ public class MarkdownMacroRenderer
      */
     public String renderInlineMacro(String id, Map<String, String> parameters, String content)
     {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
 
         buffer.append("#[");
         buffer.append(id);
@@ -112,7 +114,11 @@ public class MarkdownMacroRenderer
 
     protected String renderBlockMacro(String id, Map<String, String> parameters, String content, boolean withNewLines)
     {
-        StringBuffer buffer = new StringBuffer();
+        if (id.equals(HTML_ID)) {
+            return content;
+        }
+
+        StringBuilder buffer = new StringBuilder();
 
         // Print begin macro
         buffer.append(MACRO_OPEN_SYMBOL);
@@ -129,7 +135,7 @@ public class MarkdownMacroRenderer
             buffer.append(SLASH + MACRO_CLOSE_SYMBOL);
         } else {
             buffer.append(MACRO_CLOSE_SYMBOL);
-            if (content.length() > 0) {
+            if (!content.isEmpty()) {
                 if (withNewLines) {
                     buffer.append(NEWLINE);
                 }

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html2.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html2.test
@@ -3,7 +3,7 @@
 .inputexpect|markdown/1.2
 .# Test inline XHTML
 .#-----------------------------------------------------
-hello **<del>world</del>**<br/><sup>beta</sup>
+hello **<del>world</del>** <sup>beta</sup>
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
@@ -16,9 +16,7 @@ beginMacroMarkerInline [html] [clean=false] [<del>world</del>]
 onRawText [<del>world</del>] [xhtml/1.0]
 endMacroMarkerInline [html] [clean=false] [<del>world</del>]
 endFormat [BOLD]
-beginMacroMarkerInline [html] [clean=false] [<br/>]
-onRawText [<br/>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [<br/>]
+onSpace
 beginMacroMarkerInline [html] [clean=false] [<sup>beta</sup>]
 onRawText [<sup>beta</sup>] [xhtml/1.0]
 endMacroMarkerInline [html] [clean=false] [<sup>beta</sup>]
@@ -27,4 +25,4 @@ endDocument
 .#-----------------------------------------------------
 .expect|xhtml/1.0
 .#-----------------------------------------------------
-<p>hello <strong><del>world</del></strong><br/><sup>beta</sup></p>
+<p>hello <strong><del>world</del></strong> <sup>beta</sup></p>

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html2.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html2.test
@@ -3,7 +3,7 @@
 .inputexpect|markdown/1.2
 .# Test inline XHTML
 .#-----------------------------------------------------
-hello **<del>world</del>** <sup>beta</sup>
+hello **<del>world</del>**<br/><sup>beta</sup>
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
@@ -12,25 +12,19 @@ beginParagraph
 onWord [hello]
 onSpace
 beginFormat [BOLD]
-beginMacroMarkerInline [html] [clean=false] [<del>]
-onRawText [<del>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [<del>]
-onWord [world]
-beginMacroMarkerInline [html] [clean=false] [</del>]
-onRawText [</del>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [</del>]
+beginMacroMarkerInline [html] [clean=false] [<del>world</del>]
+onRawText [<del>world</del>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<del>world</del>]
 endFormat [BOLD]
-onSpace
-beginMacroMarkerInline [html] [clean=false] [<sup>]
-onRawText [<sup>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [<sup>]
-onWord [beta]
-beginMacroMarkerInline [html] [clean=false] [</sup>]
-onRawText [</sup>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [</sup>]
+beginMacroMarkerInline [html] [clean=false] [<br/>]
+onRawText [<br/>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<br/>]
+beginMacroMarkerInline [html] [clean=false] [<sup>beta</sup>]
+onRawText [<sup>beta</sup>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<sup>beta</sup>]
 endParagraph
 endDocument
 .#-----------------------------------------------------
 .expect|xhtml/1.0
 .#-----------------------------------------------------
-<p>hello <strong><del>world</del></strong> <sup>beta</sup></p>
+<p>hello <strong><del>world</del></strong><br/><sup>beta</sup></p>

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html3.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html3.test
@@ -35,15 +35,11 @@ onSpace
 onWord [is]
 onSpace
 beginMacroMarkerInline [html] [clean=false] [<span
-class="red">]
+class="red">good</span>]
 onRawText [<span
-class="red">] [xhtml/1.0]
+class="red">good</span>] [xhtml/1.0]
 endMacroMarkerInline [html] [clean=false] [<span
-class="red">]
-onWord [good]
-beginMacroMarkerInline [html] [clean=false] [</span>]
-onRawText [</span>] [xhtml/1.0]
-endMacroMarkerInline [html] [clean=false] [</span>]
+class="red">good</span>]
 endParagraph
 endDocument
 .#-----------------------------------------------------

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html4.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html4.test
@@ -1,0 +1,50 @@
+.runTransformations
+.#-----------------------------------------------------
+.inputexpect|markdown/1.2
+.# Test inline closing and self-closing XHTML tags
+.#-----------------------------------------------------
+hello<br/>closing tags are parsed on their own</a> and <em>non closed run until the end of
+
+the paragraph
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+onWord [hello]
+beginMacroMarkerInline [html] [clean=false] [<br/>]
+onRawText [<br/>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<br/>]
+onWord [closing]
+onSpace
+onWord [tags]
+onSpace
+onWord [are]
+onSpace
+onWord [parsed]
+onSpace
+onWord [on]
+onSpace
+onWord [their]
+onSpace
+onWord [own]
+beginMacroMarkerInline [html] [clean=false] [</a>]
+onRawText [</a>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [</a>]
+onSpace
+onWord [and]
+onSpace
+beginMacroMarkerInline [html] [clean=false] [<em>non closed run until the end of]
+onRawText [<em>non closed run until the end of] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<em>non closed run until the end of]
+endParagraph
+beginParagraph
+onWord [the]
+onSpace
+onWord [paragraph]
+endParagraph
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<p>hello<br/>closing tags are parsed on their own</a> and <em>non closed run until the end of</p><p>the paragraph</p>

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html5.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html5.test
@@ -1,0 +1,30 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|markdown/1.2
+.# Test inline HTML with embedded markdown
+.#-----------------------------------------------------
+_italic_ and <strong>_bold + italic_</strong>
+.#-----------------------------------------------------
+.expect|markdown/1.2
+.#-----------------------------------------------------
+_italic_ and <strong><em>bold + italic</em></strong>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+beginFormat [ITALIC]
+onWord [italic]
+endFormat [ITALIC]
+onSpace
+onWord [and]
+onSpace
+beginMacroMarkerInline [html] [clean=false] [<strong><em>bold + italic</em></strong>]
+onRawText [<strong><em>bold + italic</em></strong>] [xhtml/1.0]
+endMacroMarkerInline [html] [clean=false] [<strong><em>bold + italic</em></strong>]
+endParagraph
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<p><em>italic</em> and <strong><em>bold + italic</em></strong></p>

--- a/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html6.test
+++ b/syntax-markdown-commonmark12/src/test/resources/markdown12/specific/html6.test
@@ -1,0 +1,20 @@
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Test Markdown symbols in HTML macros are escaped
+.#-----------------------------------------------------
+Hello {{html clean=false}}<strong>bold and *not italic*</strong>{{/html}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+onWord [Hello]
+onSpace
+onMacroInline [html] [clean=false] [<strong>bold and *not italic*</strong>]
+endParagraph
+endDocument
+.#-----------------------------------------------------
+.expect|markdown/1.2
+.#-----------------------------------------------------
+Hello <strong>bold and \*not italic\*</strong>
+.#-----------------------------------------------------

--- a/syntax-markdown-github10/src/test/java/org/xwiki/contrib/rendering/markdown/github10/internal/GitHub10SpecificTest.java
+++ b/syntax-markdown-github10/src/test/java/org/xwiki/contrib/rendering/markdown/github10/internal/GitHub10SpecificTest.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.contrib.rendering.markdown.commonmark12.internal;
+package org.xwiki.contrib.rendering.markdown.github10.internal;
 
 import org.junit.runner.RunWith;
 import org.xwiki.rendering.test.integration.RenderingTestSuite;


### PR DESCRIPTION
This fixes the remaining issues with the conversion from RawBlocks to HTML macros:
- Skip macro rendering for HTML macros since they are supported natively in Markdown syntax.
- Parse inline HTML as valid macros by including both their content and closing tag, through a parsing post-processor.